### PR TITLE
expand vibratord stack size

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -36,7 +36,7 @@ config VIBRATOR_PRIORITY
 
 config VIBRATOR_STACKSIZE
 	int "stack size"
-	default 4096
+	default 8192
 
 config VIBRATOR_TEST
 	bool "vibrator api test"


### PR DESCRIPTION
qemu environment：
/proc/49/stack                                                   
StackAlloc: 0x40914168                                           
StackBase:  0x409141d0                                           
StackSize:  8088                                                 
StackUsed:  3832                                                 
StackMax:   3032                                                 
Size        Backtrace                                            
128         property_connect+0/0x8c                              
88          property_get_binary+0/0xdc                           
32          property_get+0/0x98                                  
288         property_get_int32+0/0x7c                            
0           receive_get_intensity+0/0x40                         
40          vibrator_mode_select+0/0x2bc                         
48          connection_poll_cb+0/0xec                            
32          uv__poll_io+0/0x98                                   
1216        uv__io_poll+0/0x5e4                                  
56          uv_run+0/0x224                                       
1104        vibratord_main+0/0x1b4 